### PR TITLE
chore(filler): always delete output directory with no tests (without specifying `--no-html`)

### DIFF
--- a/src/pytest_plugins/filler/filler.py
+++ b/src/pytest_plugins/filler/filler.py
@@ -1163,6 +1163,7 @@ def pytest_collection_modifyitems(
         items.pop(i)
 
 
+@pytest.hookimpl(hookwrapper=True, tryfirst=True)
 def pytest_sessionfinish(session: pytest.Session, exitstatus: int):
     """
     Perform session finish tasks.
@@ -1180,23 +1181,25 @@ def pytest_sessionfinish(session: pytest.Session, exitstatus: int):
         pre_alloc_groups_folder = fixture_output.pre_alloc_groups_folder_path
         pre_alloc_groups_folder.mkdir(parents=True, exist_ok=True)
         session.config.pre_alloc_groups.to_folder(pre_alloc_groups_folder)
-        return
 
     if xdist.is_xdist_worker(session):
+        yield
         return
 
     if fixture_output.is_stdout or is_help_or_collectonly_mode(session.config):
+        yield
         return
 
     # Remove any lock files that may have been created.
     for file in fixture_output.directory.rglob("*.lock"):
         file.unlink()
 
-    # Generate index file for all produced fixtures.
+    yield  # ensure that the following runs after pytest-html's pytest_sessionfinish hook
+
+    # Generate index file for all produced fixtures, respectively remove output dir.
     if session.config.getoption("generate_index") and not session.config.getoption(
         "generate_pre_alloc_groups"
     ):
-        # only create fixtures dir if at least one test was filled
         amount_of_collected_tests = getattr(session, "testscollected", 0)
         if amount_of_collected_tests > 0:
             generate_fixtures_index(
@@ -1206,17 +1209,7 @@ def pytest_sessionfinish(session: pytest.Session, exitstatus: int):
                 disable_infer_format=False,
             )
         else:
-            # nuke the fixtures dir, but only if:
-            #      * html output is disabled
-            # and
-            #      * no tests were filled
-            html_output_is_enabled = getattr(session.config.option, "htmlpath", None)
-            if not html_output_is_enabled:
-                # determine chosen fixtures output folder
-                fixture_output_obj: FixtureOutput = FixtureOutput.from_config(session.config)
-                fixture_output_folder: Path = fixture_output_obj.output_path
-                # and delete it
-                shutil.rmtree(fixture_output_folder)
+            shutil.rmtree(fixture_output.output_path)
 
     # Create tarball of the output directory if the output is a tarball.
     fixture_output.create_tarball()


### PR DESCRIPTION
## 🗒️ Description

Some suggestions no how we can solve https://github.com/ethereum/execution-specs/issues/1548 without having to add `--no-html`.

This:
- Uses a hook wrapper to make sure that we delete the directory after the pytest-html plugin has written its html output.
- Filters out the pytest-html "Generated html report:" line from the summary to avoid confusion.

The whole thing is hacky, but it's a better solution imo. This
- The logic in `pytest_terminal_summary` is worse/more complex.
- The logic in `ptyest_sessionfinish` is slightly better.

If we want to be less hacky, then the other option is to stop generating html by default. 
## 🔗 Related Issues
<!-- Reference any related issues using the GitHub issue number (e.g., Fixes ethereum/execution-spec-tests#123) -->

## ✅ Checklist
- [ ] All: Set appropriate labels for the changes.
- [ ] All: Considered squashing commits to improve commit history.
- [ ] All: Added an entry to [CHANGELOG.md](/ethereum/execution-spec-tests/blob/main/docs/CHANGELOG.md).
- [ ] All: Considered updating the online docs in the [./docs/](/ethereum/execution-spec-tests/blob/main/docs/) directory.
- [ ] Tests: All converted JSON/YML tests from [ethereum/tests](/ethereum/tests) have been added to [converted-ethereum-tests.txt](/ethereum/execution-spec-tests/blob/main/converted-ethereum-tests.txt).
- [ ] Tests: A PR with removal of converted JSON/YML tests from [ethereum/tests](/ethereum/tests) have been opened.
- [ ] Tests: Included the type and version of evm t8n tool used to locally execute test cases:  e.g., ref with commit hash or geth 1.13.1-stable-3f40e65.
- [ ] Tests: Ran `mkdocs serve` locally and verified the auto-generated docs for new tests in the [Test Case Reference](https://ethereum.github.io/execution-spec-tests/main/tests/) are correctly formatted.
